### PR TITLE
ユーザーログイン、新規登録画面のビュー作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,35 @@ belongs_to :item
 belongs_to :user
 
 
+//フッター部分
+.payment-footer{
+  text-align: center;
+  height: 300px;
+  &__list{
+    padding-top: 30px;
+    &__privacy{
+      font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
+      margin: 30px 0;
+      box-sizing: border-box;
+      font-size: 12px;
+      &__message{
+        margin: 10px;
+        &:hover{
+          border-bottom: 1px solid;
+          width: fit-content;
+          margin: 10px auto;
+        }
+      }
+    }
+  }
+  &__logo{
+    &__icon{
+      padding-top: 30px;
+    }
+  }
+  &__company{
+    text-align: center;
+    font-size: 13px;
+    font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
+  }
+}

--- a/app/assets/stylesheets/_user-phone.scss
+++ b/app/assets/stylesheets/_user-phone.scss
@@ -49,19 +49,11 @@
     }
   }
 }
-#phone{
+
+#top3_2_phone{
   background-color: red;
   &:before{
     background-color: red;
-  }
-  &:after{
-    background-color: red;
-  }
-}
-#top3_4{
-  background-color: red;
-  &:before{
-    background-color:red;
   }
 }
 

--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -874,11 +874,11 @@ $FM-color-gry:#eee;
   background-color: red;
 }
 
-#top3_3{
+#top3_3_3{
   background-color: red;
 }
 
-#top3_3::before{
+#top3_3_3::before{
   background-color: red;
 }
 
@@ -889,6 +889,14 @@ $FM-color-gry:#eee;
 }
 
 /*--------------------------------------- ユーザー新規登録ページ/ウィザード(支払い方法) --------------------------------------- */
+#top3_3{
+  background-color: red;
+}
+
+#top3_3::before{
+  background-color: red;
+}
+
 #top3_3::after{
   background-color: red;
 }

--- a/app/assets/stylesheets/payment.scss
+++ b/app/assets/stylesheets/payment.scss
@@ -108,34 +108,34 @@
   }
 }
 //フッター部分
-.payment-footer{
-  text-align: center;
-  height: 300px;
-  &__list{
-    padding-top: 30px;
-    &__privacy{
-      font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
-      margin: 30px 0;
-      box-sizing: border-box;
-      font-size: 12px;
-      &__message{
-        margin: 10px;
-        &:hover{
-          border-bottom: 1px solid;
-          width: fit-content;
-          margin: 10px auto;
-        }
-      }
-    }
-  }
-  &__logo{
-    &__icon{
-      padding-top: 30px;
-    }
-  }
-  &__company{
-    text-align: center;
-    font-size: 13px;
-    font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
-  }
-}
+// .payment-footer{
+//   text-align: center;
+//   height: 300px;
+//   &__list{
+//     padding-top: 30px;
+//     &__privacy{
+//       font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
+//       margin: 30px 0;
+//       box-sizing: border-box;
+//       font-size: 12px;
+//       &__message{
+//         margin: 10px;
+//         &:hover{
+//           border-bottom: 1px solid;
+//           width: fit-content;
+//           margin: 10px auto;
+//         }
+//       }
+//     }
+//   }
+//   &__logo{
+//     &__icon{
+//       padding-top: 30px;
+//     }
+//   }
+//   &__company{
+//     text-align: center;
+//     font-size: 13px;
+//     font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
+//   }
+// }

--- a/app/assets/stylesheets/payment.scss
+++ b/app/assets/stylesheets/payment.scss
@@ -107,35 +107,4 @@
     }
   }
 }
-//フッター部分
-// .payment-footer{
-//   text-align: center;
-//   height: 300px;
-//   &__list{
-//     padding-top: 30px;
-//     &__privacy{
-//       font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
-//       margin: 30px 0;
-//       box-sizing: border-box;
-//       font-size: 12px;
-//       &__message{
-//         margin: 10px;
-//         &:hover{
-//           border-bottom: 1px solid;
-//           width: fit-content;
-//           margin: 10px auto;
-//         }
-//       }
-//     }
-//   }
-//   &__logo{
-//     &__icon{
-//       padding-top: 30px;
-//     }
-//   }
-//   &__company{
-//     text-align: center;
-//     font-size: 13px;
-//     font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
-//   }
-// }
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,8 +8,8 @@
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body
-    = render "./items/header"
+    -# = render "./items/header"
     = yield
-    = render './items/footer'
+    -# = render './items/footer'
 
 

--- a/app/views/users/new/deliver_address.html.haml
+++ b/app/views/users/new/deliver_address.html.haml
@@ -14,7 +14,7 @@
             .newuser__header--right__progress-ab#top3_2
           %li.newuser__header--right__list
             %p お届け先住所入力
-            .newuser__header--right__progress-ab#top3_3
+            .newuser__header--right__progress-ab#top3_3_3
           %li.newuser__header--right__list
             %p 支払い方法
             .newuser__header--right__progress-ab
@@ -76,4 +76,18 @@
               %li= f.text_field :tell, class: 'delibver__right__input', placeholder: '例)090-1234-5678'
               = f.submit '次へ進む', class: 'newuser__body__input__send'
 
-  
+  .login-footer
+    .login-footer__list
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
+          プライバシーポリシー
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
+          メルカリ利用規約
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
+          特定商取引に関する表記
+    = link_to root_path, class: "login-footer__logo" do
+      = image_tag "logo_gray.svg", size: "200x90", class: "login-footer__logo__icon"
+    .login-footer__company
+      © Fmarket, Inc.

--- a/app/views/users/new/payment.html.haml
+++ b/app/views/users/new/payment.html.haml
@@ -53,18 +53,18 @@
             カードの裏面の番号とは？
         .payment-info__botton
           = link_to "次へ進む", root_path, class: "payment-info__botton__link"
-  .payment-footer
-    .payment-footer__list
-      = link_to "#", class: "payment-footer__list__privacy" do
-        .payment-footer__list__privacy__message
+  .login-footer
+    .login-footer__list
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
           プライバシーポリシー
-      = link_to "#", class: "payment-footer__list__privacy" do
-        .payment-footer__list__privacy__message
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
           メルカリ利用規約
-      = link_to "#", class: "payment-footer__list__privacy" do
-        .payment-footer__list__privacy__message
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
           特定商取引に関する表記
-    = link_to root_path, class: "payment-footer__logo" do
-      = image_tag "logo_gray.svg", size: "200x90", class: "payment-footer__logo__icon"
-    .payment-footer__company
+    = link_to root_path, class: "login-footer__logo" do
+      = image_tag "logo_gray.svg", size: "200x90", class: "login-footer__logo__icon"
+    .login-footer__company
       © Fmarket, Inc.

--- a/app/views/users/new/phone.html.haml
+++ b/app/views/users/new/phone.html.haml
@@ -11,13 +11,13 @@
             .newuser__header--right__progress-a#top3_1
           %li.newuser__header--right__list
             %p 電話番号認証
-            .newuser__header--right__progress-ab#top3_2
+            .newuser__header--right__progress-ab#top3_2_phone
           %li.newuser__header--right__list
             %p お届け先住所入力
-            .newuser__header--right__progress-ab#top3_3#phone
+            .newuser__header--right__progress-ab
           %li.newuser__header--right__list
             %p 支払い方法
-            .newuser__header--right__progress-ab#top3_4
+            .newuser__header--right__progress-ab
           %li.newuser__header--right__list
             %p 完了
             .newuser__header--right__progress-b

--- a/app/views/users/new/registerdone.html.haml
+++ b/app/views/users/new/registerdone.html.haml
@@ -41,18 +41,18 @@
           = image_tag "apple.png", size: "200x80", class: "toppage-logo"
         = link_to "https://play.google.com/store/apps/details?id=com.kouzoh.mercari&hl=ja", target: "_blank", class: "registerdone-app" do
           = image_tag "google-play.png", size: "200x80", class: "toppge-logo"
-  .payment-footer
-    .payment-footer__list
-      = link_to "#", class: "payment-footer__list__privacy" do
-        .payment-footer__list__privacy__message
+  .login-footer
+    .login-footer__list
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
           プライバシーポリシー
-      = link_to "#", class: "payment-footer__list__privacy" do
-        .payment-footer__list__privacy__message
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
           メルカリ利用規約
-      = link_to "#", class: "payment-footer__list__privacy" do
-        .payment-footer__list__privacy__message
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
           特定商取引に関する表記
-    = link_to root_path, class: "payment-footer__logo" do
-      = image_tag "logo_gray.svg", size: "200x90", class: "payment-footer__logo__icon"
-    .payment-footer__company
+    = link_to root_path, class: "login-footer__logo" do
+      = image_tag "logo_gray.svg", size: "200x90", class: "login-footer__logo__icon"
+    .login-footer__company
       © Fmarket, Inc.

--- a/app/views/users/new/user_info.html.haml
+++ b/app/views/users/new/user_info.html.haml
@@ -21,6 +21,7 @@
           %li.newuser__header--right__list
             %p 完了
             .newuser__header--right__progress-b
+
   .newuser__body
     .newuser__body__content
       %h2.newuser__body__content__head 会員情報入力
@@ -53,6 +54,7 @@
               %h1 本人確認
               %p 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
               
+
             .newuser__body__content__group
               %ul.newuser__body__content__group__top.flex
                 %li.newuser__body__content__group__name お名前(全角)
@@ -75,6 +77,7 @@
                 != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'XXXXX', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
               %p.gry__message ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
 
+
               .newuser__body__content__terms
                 「次へ進む」のボタンを押すことにより,
                 = link_to '利用規約' 
@@ -90,4 +93,19 @@
                 =link_to 'Terms of Service '
                 apply.
 
+  .login-footer
+    .login-footer__list
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
+          プライバシーポリシー
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
+          メルカリ利用規約
+      = link_to "#", class: "login-footer__list__privacy" do
+        .login-footer__message
+          特定商取引に関する表記
+    = link_to root_path, class: "login-footer__logo" do
+      = image_tag "logo_gray.svg", size: "200x90", class: "login-footer__logo__icon"
+    .login-footer__company
+      © Fmarket, Inc.
   

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_30_101443) do
+ActiveRecord::Schema.define(version: 2019_12_30_112735) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postcode", null: false
@@ -42,6 +42,8 @@ ActiveRecord::Schema.define(version: 2019_12_30_101443) do
     t.integer "size", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_items_on_user_id"
   end
 
   create_table "phone_numbers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -73,5 +75,6 @@ ActiveRecord::Schema.define(version: 2019_12_30_101443) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "items", "users"
   add_foreign_key "phone_numbers", "users"
 end


### PR DESCRIPTION
# what
ユーザーログイン、新規登録画面のビューの実装をしました。
ビューの画像
新規登録ページ
https://gyazo.com/1dd14ba116d0c0d728cb1003528bc9b1
ログインページ
https://gyazo.com/2d64ae627c7c88c25442197b15df4f4b
会員情報ページ
https://gyazo.com/55049a81c35e8db030dba32532bfc5a2
https://gyazo.com/c8ee8d2a62207b84ea00ff289da73d74
電話番号確認ページ
https://gyazo.com/899fcc9921b9bf9353912a2f08ceb381
お届け先住所入力ページ
https://gyazo.com/096ecf89abbc3fb80f36e36573159b7d
https://gyazo.com/efc4337860d2f0187a0facbcfffbbe5e
支払い方法ページ
https://gyazo.com/832cd49dc520201955a3df9de1af4df7
会員登録完了ページ
https://gyazo.com/e474b7d9f25d3616d54d17df69729aa5
# why
ユーザーの登録画面を整えるため。