### PR TITLE
(wip)【サーバサイド】商品一覧表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,32 +2,23 @@ class ItemsController < ApplicationController
   def index
     @items = Item.includes(:images).order('created_at DESC').limit(10)
 
-    # @items_women = Item.Where(:genre, '').limit(10)
-    # @items_men = Item.Where(:genre, '').limit(10)
-    # @items_appliances = Item.Where(:genre, '').limit(10)
-    # @items_hobby = Item.Where(:genre, '').limit(10)
+    #レディースに関するインスタンス
+    @items_women = Item.where(genre: '1').limit(10)
+    #メンズに関するインスタンス
+    @items_men = Item.where(genre: '2').limit(10)
+    #家電に関するインスタンス
+    @items_appliances = Item.where(genre: '8').limit(10)
+    #ホビーに関するインスタンス
+    @items_hobby = Item.where(genre: '6').limit(10)
     
-    # カテゴリーに関するインスタンスの作成
-    # @items.each do |item|
-    #   if item.genre == 1
-    #     @items_women.push(item)
-    #   elsif item.genre == 2
-    #     @items_men.push(item)
-    #   elsif item.genre == 3
-    #     @items_appliances.push(item)
-    #   elsif item.genre == 4
-    #     @items_hobby.push(item)
-    #   end
-  # end
-
-  #   #ブランドに関するインスタンスの作成
-  #   # @items.each do |item|
-  #   # end
-
-  #   @items_chanel =Item.where()
-  #   @items_supreme =Item.where()
-  #   @items_nike =Item.where()
-
+    #ブランドに関するインスタンスの作成
+    @items_chanel =Item.where(brand: '1').limit(10)
+    #ルイヴィトンに関するインスタンス
+    @items_vuitton =Item.where(brand: '3').limit(10)
+    #シュプリームに関するインスタンス
+    @items_supreme =Item.where(brand: '4').limit(10)
+    #ナイキに関するインスタンス
+    @items_nike =Item.where(brand: '2').limit(10)
   end
 
   def show

--- a/app/views/items/_index.html.haml
+++ b/app/views/items/_index.html.haml
@@ -1,0 +1,16 @@
+.toppage-list
+  .tppage-container
+    .toppage__items
+      .toppage__items__name
+        ="#{genre}新着アイテム"
+      =link_to "もっと見る ＞", '#', class: "toppage__items__button"
+    .toppage__block
+      -items.each do |item|
+        .toppage__block__goods
+          = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
+            /一枚目の画像取得
+            = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
+            .toppage__block__goods__link__words
+              =item.name
+          .toppage__block__goods__price
+            = converting_to_jpy(item.price)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -39,7 +39,7 @@
       .toppage__block
         -@items_women.each do |item|
           .toppage__block__goods
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
@@ -57,7 +57,7 @@
         /商品データ
         -@items_men.each do |item|
           .toppage__block__goods
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
@@ -75,7 +75,7 @@
         /商品データ
         -@items_appliances.each do |item|
           .toppage__block__goods
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
@@ -93,7 +93,7 @@
         /商品データ
         -@items_hobby.each do |item|
           .toppage__block__goods
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
@@ -122,7 +122,7 @@
         /商品データ
         -@items_chanel.each do |item|
           .toppage__block__goods
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
@@ -140,7 +140,7 @@
         /商品データ
         -@items_vuitton.each do |item|
           .toppage__block__goods
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
@@ -158,7 +158,7 @@
         /商品データ
         -@items_supreme.each do |item|
           .toppage__block__goods
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
@@ -177,7 +177,7 @@
         -@items_nike.each do |item|
           .toppage__block__goods
             /一枚目の画像取得
-            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -39,7 +39,7 @@
           レディース新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
-        -@items.each do |item|
+        -@items_women.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
@@ -55,10 +55,10 @@
           メンズ新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
-        -@items.each do |item|
+        -@items_men.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
-              = image_tag "image4.jpg", class: "toppage__block__goods__link__image"
+              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
@@ -70,10 +70,10 @@
           家電・スマホ・カメラ新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
-        -@items.each do |item|
+        -@items_appliances.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
-              = image_tag "image4.jpg", class: "toppage__block__goods__link__image"
+              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
@@ -85,10 +85,10 @@
           おもちゃ・ホビー・グッズ新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
-        -@items.each do |item|
+        -@items_hobby.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
-              = image_tag "image4.jpg", class: "toppage__block__goods__link__image"
+              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
@@ -111,61 +111,59 @@
           シャネル新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
-        .toppage__block__goods
-          = link_to "#", target: "_blank", class: "toppage__block__goods__link" do
-            = image_tag "image4.jpg", class: "toppage__block__goods__link__image"
-            .toppage__block__goods__link__words
-              カバン
-          .toppage__block__goods__price
-            ¥100,000
-        .toppage__block2__goods
-          = link_to "#", target: "_blank", class: "toppage__block2__goods__link" do
-            = image_tag "image4.jpg", size: "60×60", class: "toppage__block2__goods__link__image"
-            .toppage__block2__goods__link__words
-              カバン
-          .toppage__block2__goods__price
-            ¥100,000
-        .toppage__block__goods
-          = link_to "#", target: "_blank", class: "toppage__block__goods__link" do
-            = image_tag "image4.jpg", class: "toppage__block__goods__link__image"
-            .toppage__block__goods__link__words
-              カバン
-          .toppage__block__goods__price
-            ¥100,000
-        .toppage__block2__goods
-          = link_to "#", target: "_blank", class: "toppage__block2__goods__link" do
-            = image_tag "image4.jpg", size: "60×60", class: "toppage__block2__goods__link__image"
-            .toppage__block2__goods__link__words
-              カバン
-          .toppage__block2__goods__price
-            ¥100,000
-        .toppage__block__goods
-          = link_to "#", target: "_blank", class: "toppage__block__goods__link" do
-            = image_tag "image4.jpg", class: "toppage__block__goods__link__image"
-            .toppage__block__goods__link__words
-              カバン
-          .toppage__block__goods__price
-            ¥100,000
-        .toppage__block2__goods
-          = link_to "#", target: "_blank", class: "toppage__block2__goods__link" do
-            = image_tag "image4.jpg", size: "60×60", class: "toppage__block2__goods__link__image"
-            .toppage__block2__goods__link__words
-              カバン
-          .toppage__block2__goods__price
-            ¥100,000
-        .toppage__block__goods
-          = link_to "#", target: "_blank", class: "toppage__block__goods__link" do
-            = image_tag "image4.jpg", class: "toppage__block__goods__link__image"
-            .toppage__block__goods__link__words
-              カバン
-          .toppage__block__goods__price
-            ¥100,000
-        .toppage__block2__goods
-          = link_to "#", target: "_blank", class: "toppage__block2__goods__link" do
-            = image_tag "image4.jpg", size: "60×60", class: "toppage__block2__goods__link__image"
-            .toppage__block2__goods__link__words
-              カバン
-          .toppage__block2__goods__price
-            ¥100,000
+        -@items_chanel.each do |item|
+          .toppage__block__goods
+            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
+              .toppage__block__goods__link__words
+                =item.name
+            .toppage__block__goods__price
+              = converting_to_jpy(item.price)
+  .toppage-list
+    .tppage-container
+      .toppage__items
+        .toppage__items__name
+          ルイヴィトン新着アイテム
+        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
+      .toppage__block
+        -@items_vuitton.each do |item|
+          .toppage__block__goods
+            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
+              .toppage__block__goods__link__words
+                =item.name
+            .toppage__block__goods__price
+              = converting_to_jpy(item.price)
+  .toppage-list
+    .tppage-container
+      .toppage__items
+        .toppage__items__name
+          シュプリーム新着アイテム
+        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
+      .toppage__block
+        -@items_supreme.each do |item|
+          .toppage__block__goods
+            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
+              .toppage__block__goods__link__words
+                =item.name
+            .toppage__block__goods__price
+              = converting_to_jpy(item.price)
+  .toppage-list
+    .tppage-container
+      .toppage__items
+        .toppage__items__name
+          ナイキ新着アイテム
+        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
+      .toppage__block
+        -@items_nike.each do |item|
+          .toppage__block__goods
+            = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
+              .toppage__block__goods__link__words
+                =item.name
+            .toppage__block__goods__price
+              = converting_to_jpy(item.price)
+        
 
 =render 'items/footer'

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -21,6 +21,7 @@
     .slider-images
       = link_to "#", target: "_blank" do
         = image_tag "image1.jpeg", height: "400px", width: "100%"
+  /カテゴリーに関する一覧
   .toppage__category
     .toppage__category__heading
       人気のカテゴリー
@@ -30,79 +31,15 @@
         =link_to "家電・スマホ・カメラ", '#', class: "toppage__category__heading__type__btn"
         =link_to "おもちゃ・ホビー・グッズ", '#', class: "toppage__category__heading__type__btn"
   /レディース商品
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          レディース新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        -@items_women.each do |item|
-          .toppage__block__goods
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              /一枚目の画像取得
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_women ,genre: 'レディース'}
   /メンズ商品関連商品一覧
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          メンズ新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        /商品データ
-        -@items_men.each do |item|
-          .toppage__block__goods
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              /一枚目の画像取得
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_men ,genre: 'メンズ'}
   /家電・スマホ・カメラ関連商品一覧
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          家電・スマホ・カメラ新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        /商品データ
-        -@items_appliances.each do |item|
-          .toppage__block__goods
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              /一枚目の画像取得
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_appliances ,genre: '家電・スマホ・カメラ'}
   /おもちゃ・ホビー・グッズ関連商品一覧
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          おもちゃ・ホビー・グッズ新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        /商品データ
-        -@items_hobby.each do |item|
-          .toppage__block__goods
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              /一枚目の画像取得
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_hobby ,genre: 'おもちゃ・ホビー・グッズ'}
         
-
-
+  /ブランドに関する一覧
   .toppage__category
     .toppage__category__heading
       人気のブランド
@@ -112,77 +49,13 @@
         =link_to "シュプリーム", '#', class: "toppage__category__heading__type__btn"
         =link_to "ナイキ", '#', class: "toppage__category__heading__type__btn"
   /シャネル関連商品一覧
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          シャネル新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        /商品データ
-        -@items_chanel.each do |item|
-          .toppage__block__goods
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              /一枚目の画像取得
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_chanel ,genre: 'シャネル'}
   /ルイヴィトン関連商品一覧
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          ルイヴィトン新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        /商品データ
-        -@items_vuitton.each do |item|
-          .toppage__block__goods
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              /一枚目の画像取得
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_vuitton ,genre: 'ルイヴィトン'}
   /シュプリーム関連商品一覧
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          シュプリーム新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        /商品データ
-        -@items_supreme.each do |item|
-          .toppage__block__goods
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              /一枚目の画像取得
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_supreme ,genre: 'シュプリーム'}
   /ナイキ関連商品一覧
-  .toppage-list
-    .tppage-container
-      .toppage__items
-        .toppage__items__name
-          ナイキ新着アイテム
-        =link_to "もっと見る ＞", '#', class: "toppage__items__button"
-      .toppage__block
-        /商品データ
-        -@items_nike.each do |item|
-          .toppage__block__goods
-            /一枚目の画像取得
-            = link_to item_path(item.id), target: "_blank", class: "toppage__block__goods__link" do
-              = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
-              .toppage__block__goods__link__words
-                =item.name
-            .toppage__block__goods__price
-              = converting_to_jpy(item.price)
+  = render partial: 'index', locals: { 'items': @items_nike ,genre: 'ナイキ'}
         
 
 =render 'items/footer'

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -21,9 +21,6 @@
     .slider-images
       = link_to "#", target: "_blank" do
         = image_tag "image1.jpeg", height: "400px", width: "100%"
-
-
-
   .toppage__category
     .toppage__category__heading
       人気のカテゴリー
@@ -32,6 +29,7 @@
         =link_to "メンズ", '#', class: "toppage__category__heading__type__btn"
         =link_to "家電・スマホ・カメラ", '#', class: "toppage__category__heading__type__btn"
         =link_to "おもちゃ・ホビー・グッズ", '#', class: "toppage__category__heading__type__btn"
+  /レディース商品
   .toppage-list
     .tppage-container
       .toppage__items
@@ -42,12 +40,13 @@
         -@items_women.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
               = converting_to_jpy(item.price)
-
+  /メンズ商品関連商品一覧
   .toppage-list
     .tppage-container
       .toppage__items
@@ -55,14 +54,17 @@
           メンズ新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
+        /商品データ
         -@items_men.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
               = converting_to_jpy(item.price)
+  /家電・スマホ・カメラ関連商品一覧
   .toppage-list
     .tppage-container
       .toppage__items
@@ -70,14 +72,17 @@
           家電・スマホ・カメラ新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
+        /商品データ
         -@items_appliances.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
               = converting_to_jpy(item.price)
+  /おもちゃ・ホビー・グッズ関連商品一覧
   .toppage-list
     .tppage-container
       .toppage__items
@@ -85,9 +90,11 @@
           おもちゃ・ホビー・グッズ新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
+        /商品データ
         -@items_hobby.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
@@ -104,6 +111,7 @@
         =link_to "ルイヴィトン", '#', class: "toppage__category__heading__type__btn"
         =link_to "シュプリーム", '#', class: "toppage__category__heading__type__btn"
         =link_to "ナイキ", '#', class: "toppage__category__heading__type__btn"
+  /シャネル関連商品一覧
   .toppage-list
     .tppage-container
       .toppage__items
@@ -111,14 +119,17 @@
           シャネル新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
+        /商品データ
         -@items_chanel.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
               = converting_to_jpy(item.price)
+  /ルイヴィトン関連商品一覧
   .toppage-list
     .tppage-container
       .toppage__items
@@ -126,14 +137,17 @@
           ルイヴィトン新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
+        /商品データ
         -@items_vuitton.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
               = converting_to_jpy(item.price)
+  /シュプリーム関連商品一覧
   .toppage-list
     .tppage-container
       .toppage__items
@@ -141,14 +155,17 @@
           シュプリーム新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
+        /商品データ
         -@items_supreme.each do |item|
           .toppage__block__goods
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
+              /一枚目の画像取得
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words
                 =item.name
             .toppage__block__goods__price
               = converting_to_jpy(item.price)
+  /ナイキ関連商品一覧
   .toppage-list
     .tppage-container
       .toppage__items
@@ -156,8 +173,10 @@
           ナイキ新着アイテム
         =link_to "もっと見る ＞", '#', class: "toppage__items__button"
       .toppage__block
+        /商品データ
         -@items_nike.each do |item|
           .toppage__block__goods
+            /一枚目の画像取得
             = link_to "/items/#{item.id}", target: "_blank", class: "toppage__block__goods__link" do
               = image_tag item.images[0].src.to_s, class: "toppage__block__goods__link__image"
               .toppage__block__goods__link__words


### PR DESCRIPTION
## what
1.商品一覧ページへのルーティング
2.商品情報を取得し、viewに反映
3.コントーローラにて、カテゴリ毎のitemレコードを取得

## why
1.カテゴリー毎の商品の一覧データの表示の実装
2.商品出品機能実装後、スムーズに一覧機能をアプリに実装するため.

## 注意事項
出品機能が不完全なため,画像の表示が出来ていない
上記について、カラムのデータを取得するコードは記述は実装済み。